### PR TITLE
ci: route linux x64 jobs to self-hosted podman fleet

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
   # Pre-deployment validation
   pre-deployment:
     name: "🔍 Pre-deployment Validation"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event.inputs.skip_tests != 'true'
     permissions:
       contents: read
@@ -117,7 +117,7 @@ jobs:
   # Staging deployment
   deploy-staging:
     name: "🎭 Deploy to Staging"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [pre-deployment]
     if: always() && (needs.pre-deployment.outputs.deployment-ready == 'true' || github.event.inputs.force_deploy == 'true')
     environment:
@@ -231,7 +231,7 @@ jobs:
   # Production deployment (requires manual approval)
   deploy-production:
     name: "🏭 Deploy to Production"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [pre-deployment, deploy-staging]
     if: |
       always() && 
@@ -394,7 +394,7 @@ jobs:
   # Post-deployment monitoring and alerts
   post-deployment:
     name: "📊 Post-deployment Monitoring"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [deploy-production]
     if: always() && needs.deploy-production.result == 'success'
     permissions:
@@ -459,7 +459,7 @@ jobs:
   # Rollback capability
   rollback:
     name: "🔄 Rollback Deployment"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: failure() && github.event_name == 'workflow_dispatch'
     environment:
       name: production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,16 @@ name: "🔄 Continuous Integration"
 
 # Manual only — no push/pull_request CI triggers
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
     inputs:
       skip_tests:
@@ -23,7 +33,7 @@ jobs:
   # Security and vulnerability scanning
   security-scan:
     name: "🔒 Security Scan"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       security-events: write
@@ -78,7 +88,7 @@ jobs:
   # Code quality and linting
   code-quality:
     name: "✨ Code Quality"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       pull-requests: write
@@ -131,7 +141,7 @@ jobs:
   # Comprehensive testing suite
   test:
     name: "🧪 Test Suite"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event.inputs.skip_tests != 'true'
     permissions:
       contents: read
@@ -196,7 +206,7 @@ jobs:
   # Docker image building and scanning
   docker-build:
     name: "🐳 Docker Build & Scan"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       security-events: write
@@ -261,7 +271,7 @@ jobs:
   # Kubernetes manifest validation
   k8s-validation:
     name: "☸️ Kubernetes Validation"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
     
@@ -313,7 +323,7 @@ jobs:
   # Infrastructure as Code validation
   iac-validation:
     name: "🏗️ Infrastructure Validation"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
     
@@ -351,7 +361,7 @@ jobs:
   # Sourcery AI code review (simulated)
   sourcery-ai:
     name: "🤖 Sourcery AI Review"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -400,7 +410,7 @@ jobs:
   # Final CI status check
   ci-status:
     name: "✅ CI Status Check"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [security-scan, code-quality, test, docker-build, k8s-validation, iac-validation]
     if: always()
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,16 @@ name: "🔒 Security Scanning"
 
 # Manual only — no push/pull_request CI triggers
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
     inputs:
       scan_type:
@@ -43,7 +53,7 @@ jobs:
   # Static Application Security Testing (SAST)
   sast-scan:
     name: "🔍 SAST Scan"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'sast' || github.event.inputs.scan_type == ''
     permissions:
       contents: read
@@ -183,7 +193,7 @@ jobs:
   # Dependency scanning
   dependency-scan:
     name: "📦 Dependency Scan"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'dependencies' || github.event.inputs.scan_type == ''
     permissions:
       contents: read
@@ -253,7 +263,7 @@ jobs:
   # Container security scanning
   container-scan:
     name: "🐳 Container Security Scan"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'containers' || github.event.inputs.scan_type == ''
     permissions:
       contents: read
@@ -333,7 +343,7 @@ jobs:
   # Infrastructure security scanning
   infrastructure-scan:
     name: "🏗️ Infrastructure Security Scan"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'infrastructure' || github.event.inputs.scan_type == ''
     permissions:
       contents: read
@@ -422,7 +432,7 @@ jobs:
   # Secret scanning
   secret-scan:
     name: "🔑 Secret Scanning"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       security-events: write
@@ -465,7 +475,7 @@ jobs:
   # Security compliance check
   compliance-check:
     name: "📋 Security Compliance Check"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [sast-scan, dependency-scan, container-scan, infrastructure-scan]
     if: always()
     permissions:

--- a/.github/workflows/update_branches.yml
+++ b/.github/workflows/update_branches.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   discover-branches:
     name: "🔍 Discover Branches"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     outputs:
       branches: ${{ steps.branches.outputs.list }}
       total: ${{ steps.branches.outputs.total }}
@@ -93,7 +93,7 @@ jobs:
 
   update-branches:
     name: "🔄 Update ${{ matrix.branch }}"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [discover-branches]
     if: needs.discover-branches.outputs.total > 0
     strategy:
@@ -305,7 +305,7 @@ jobs:
   # Summary report
   update-summary:
     name: "📊 Update Summary"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [discover-branches, update-branches]
     if: always() && needs.discover-branches.outputs.total > 0
     


### PR DESCRIPTION
## Summary
Adapts GitHub Actions for the shared **gha-runner-ctl** WSL fleet.

## Changes
- `runs-on: [self-hosted, linux, x64, podman]` for linux x64 jobs
- Matrix/release linux legs mapped to fleet labels; macOS/Windows/ARM64 unchanged
- Push/PR triggers added on primary CI workflows that were manual-only

## Fleet labels
CPU: `[self-hosted, linux, x64, podman]` · GPU (occasional): add `gpu` label